### PR TITLE
Update NUSMods API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is an attempt to list all useful APIs available in Singapore for developers
 
 API | Description | Auth | HTTPS | Link |
 |---|---|---|---|---|
-| **NUSMods** | Unofficial API for consolidating NUS module information. Modules are the NUS equivalent of courses | `apiKey` | Yes | [View](https://github.com/nusmodifications/nusmods-api) |
+| **NUSMods** | API for consolidating NUS module information. Modules are the NUS equivalent of courses | No | Yes | [View](https://api.nusmods.com/v2/) |
 
 ### Environment
 


### PR DESCRIPTION
Hello, I am a maintainer of NUSMods. Just noticed this repo and realised that the link to the API is outdated. NUSMods is also the official timetable planner used in NUS now, so we are no longer "Unofficial".

This PR updates the information.

Thank you for collating all these data!